### PR TITLE
adiciona django-cors-headers

### DIFF
--- a/APIBoletimCovid/settings.py
+++ b/APIBoletimCovid/settings.py
@@ -50,18 +50,22 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'drf_yasg',
+    'corsheaders',
     'apicovid'
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+CORS_ORIGIN_ALLOW_ALL = True
 
 ROOT_URLCONF = 'APIBoletimCovid.urls'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 dj-database-url==0.5.0
 Django==3.0.7
+django-cors-headers==3.4.0
 django-heroku==0.3.1
 djangorestframework==3.11.0
 drf-yasg==1.17.1


### PR DESCRIPTION
No momento ele está configurado para aceitar requisições de qualquer endereço, mas devemos alterar quando for para a produção.